### PR TITLE
Support additional JPaths on data source

### DIFF
--- a/examples/extra_paths.jsonnet
+++ b/examples/extra_paths.jsonnet
@@ -1,0 +1,3 @@
+local extra = import 'extra.libsonnet';
+local lib = import 'lib.libsonnet';
+lib + extra

--- a/examples/lib-extra/extra.libsonnet
+++ b/examples/lib-extra/extra.libsonnet
@@ -1,0 +1,1 @@
+{ extra: 'data' }

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,11 +1,18 @@
-provider "jsonnet" {
-  jsonnet_path = ["./lib/"]
+terraform {
+  required_providers {
+    jsonnet = {
+      source  = "alxrem/jsonnet"
+      version = "~> 1.0"
+    }
+  }
+}
 
-  version = "~> 1.0"
+provider "jsonnet" {
+  jsonnet_path = "./lib/"
 }
 
 data "jsonnet_file" "template" {
-  ext_str  = {
+  ext_str = {
     hello = "from external string"
   }
 
@@ -28,10 +35,19 @@ data "jsonnet_file" "tla" {
   source = "tla.jsonnet"
 }
 
+data "jsonnet_file" "extra_paths" {
+  source       = "extra_paths.jsonnet"
+  jsonnet_path = "./lib-extra"
+}
+
 output "example" {
   value = data.jsonnet_file.template.rendered
 }
 
 output "tla" {
   value = data.jsonnet_file.tla.rendered
+}
+
+output "extra_paths" {
+  value = data.jsonnet_file.extra_paths.rendered
 }


### PR DESCRIPTION
My use case is to ship modules that automatically include certain libraries exposed at the provider level, while individual data sources may reference additional load paths to be able to include their own libraries.